### PR TITLE
calculte sizeof(ArtMethod)

### DIFF
--- a/Source/app/src/main/java/com/app/artful/SampleClass.java
+++ b/Source/app/src/main/java/com/app/artful/SampleClass.java
@@ -1,0 +1,13 @@
+package com.app.artful;
+
+import android.util.Log;
+
+public class SampleClass {
+    public static void f1(){
+        Log.i("SampleClass", "f1");
+    }
+
+    public static void f2() {
+        Log.i("SampleClass", "f2");
+    }
+}


### PR DESCRIPTION
 calculate the size of ArtMethod instead of define the NUM_BYTES_TO_OVERWRITE.
we can create two static functions in a SampleClass.
 because f1 and f2 are in the same ArtMethod Array of class SampleClass, and there are just only two ArtMethods in that array,
 the sizeof(ArtMethod) would be f1's offset minors f2's offset